### PR TITLE
Fix old url for repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM base AS final
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
 LABEL org.opencontainers.image.title="azure-pipelines-azurecli"
-LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-azurecli"
+LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-azurecli-net8"
 
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
The url in the DockerFile is still pointing to the dotnet6 repo